### PR TITLE
Update loguru_loki_handler.py

### DIFF
--- a/loguru_loki_handler/loguru_loki_handler.py
+++ b/loguru_loki_handler/loguru_loki_handler.py
@@ -47,7 +47,7 @@ class loki_handler:
 
         for key, val in simplified.items():
             if key in self.labelKeys:
-                self.steam.addLabel(key, val)
+                self.steam.addLabel(key, str(val))
 
         self.steam.setValue(json.dumps(simplified, ensure_ascii=False))
 


### PR DESCRIPTION
When labelkeys is a dictionary {"timestap":"123123"},like：
```python
logger.configure(handlers=[{"sink": LokiHandler(os.environ["LOKI_URL"], {"Application": os.environ["APPLICATION"], "Environment": os.environ["STAGE"]},{"timestap":"123123"}), "serialize": True}])
```
the val in self.steam.addLabel(key, val) is  int, which will result in no timestap label, so it is recommended to use str(val)